### PR TITLE
Wrap `includes` in a custom element

### DIFF
--- a/example/www/templates/www/components/include.html
+++ b/example/www/templates/www/components/include.html
@@ -1,3 +1,3 @@
-<div style='border: 1px solid red; margin: 5px;'>
+<div>
   This is a regular include.
 </div>

--- a/example/www/templates/www/components/include.html
+++ b/example/www/templates/www/components/include.html
@@ -1,3 +1,5 @@
 <div>
-  This is a regular include.
+  <p>
+    This is a regular include.
+  </p>
 </div>

--- a/example/www/templates/www/components/shadow-include.html
+++ b/example/www/templates/www/components/shadow-include.html
@@ -4,7 +4,7 @@
 
 <style>
   div {
-    border: 1px solid blue;
+    border: 1px blue solid;
     margin: 5px;
   }
 </style>

--- a/example/www/templates/www/components/shadow-include.html
+++ b/example/www/templates/www/components/shadow-include.html
@@ -1,10 +1,16 @@
 <div>
-  This is a shadow include.
+  <p>
+    This is a shadow include.
+  </p>
 </div>
 
 <style>
   div {
     border: 1px blue solid;
-    margin: 5px;
+    margin: 5px 0 5px 0;
+  }
+
+  p {
+    margin: 0;
   }
 </style>

--- a/example/www/templates/www/include.html
+++ b/example/www/templates/www/include.html
@@ -4,63 +4,118 @@
   <style>
     div {
       border: 1px solid red;
-      margin: 5px;
+      margin: 5px 0 5px 0;
     }
 
-    dj-www-components-include-additional div {
+    div p {
+      color: blue;
+      margin: 0;
+    }
+
+    dj-www-components-include-1 div {
       border: 1px green solid;
+    }
+
+    dj-www-components-include-2 div p {
+      color: green;
     }
   </style>
 
-  <pre>&lt;!-- www/components/include.html --&gt;
+  <p>
+    Demonstrate how <code>include</code> works and different ways to style components.
+  </p>
 
-&lt;div style='border: 1px solid red; margin: 5px;'&gt;
-  This is a regular include.
-&lt;/div&gt;
-</pre>
+  <h3>Page styles</h3>
 
-  <pre>&lt;!-- www/components/shadow-include.html --&gt;
-
-&lt;div&gt;
-  This is a shadow include.
-&lt;/div&gt;
-
-&lt;style&gt;
-  div {
-    border: 1px solid blue;
-    margin: 5px;
-  }
-&lt;/style&gt;
-  </pre>
-
-  <pre>&lt;!-- www/include.html --&gt;
-
+  <pre>
 &lt;style&gt;
   div {
     border: 1px solid red;
     margin: 5px;
   }
 
+  div p {
+    color: blue;
+    margin: 0;
+  }
+
   dj-www-components-include-additional div {
     border: 1px green solid;
   }
-&lt;/style&gt;
 
-&lt;!-- regular includes --&gt;
-&lt;dj-www/components/include /&gt;
+  dj-www-components-include-2 div p {
+    color: green;
+  }
+&lt;/style&gt;</pre>
+
+
+  <h3>www/components/include.html</h3>
+
+  <pre>&lt;div&gt;
+  This is a regular include.
+&lt;/div&gt;</pre>
+
+  <h4>Regular includes</h4>
+
+  <p>
+    Different ways to include <code>www/components/include.html</code>. They will all have a red border because of the
+    page style which targets <code>div</code> elements. They have blue text because of the page style which targets
+    <code>div p</code> elements.
+  </p>
+
+  <pre>&lt;dj-www/components/include /&gt;
 &lt;dj-include 'www/components/include' /&gt;
-&lt;dj-include 'www/components/include:additional' /&gt;
-&lt;dj-include 'www/components/include.html' /&gt;
-
-&lt;!-- shadow includes --&gt;
-&lt;dj-www/components/shadow-include! /&gt;
-&lt;dj-www/components/shadow-include shadow /&gt;</pre>
+&lt;dj-include 'www/components/include.html' /&gt;</pre>
 
   <dj-www/components/include />
-  <dj-www/components/include:additional />
   <dj-include 'www/components/include' />
-  <dj-include 'www/components/include:additional' />
   <dj-include 'www/components/include.html' />
+
+
+  <h4>Regular includes with an additional id</h4>
+
+  <p>
+    Add a differentiator to the wrapping element that gets created around each include. The first will have a green
+    border because of the page style which specifies <code>dj-www-components-include-1</code>. They all have blue text
+    because of the page style which targets <code>div p</code> elements.
+  </p>
+
+  <pre>&lt;dj-www/components/include:1 /&gt;
+&lt;dj-include 'www/components/include:2' /&gt;</pre>
+
+  <dj-www/components/include:1 />
+  <dj-include 'www/components/include:2' />
+
+
+  <h3>www/components/shadow-include.html</h3>
+
+  <pre>&lt;div&gt;
+  This is a shadow include.
+&lt;/div&gt;
+
+&lt;style&gt;
+  div {
+    border: 1px solid blue;
+    margin: 5px 0 5px 0;
+  }
+
+  p {
+    margin: 0;
+  }
+&lt;/style&gt;</pre>
+
+  <h4>Shadow includes</h4>
+
+  <p>
+    Different ways to include <code>www/components/shadow-include.html</code>. They will all have a blue border because
+    of the styles in the include which targets <code>div</code> elements. They will <strong>not</strong> have blue text
+    because the page style that target <code>div p</code> does not pierce the shadow DOM.
+  </p>
+
+  <pre>
+&lt;dj-www/components/shadow-include! /&gt;
+&lt;dj-www/components/shadow-include shadow /&gt;
+&lt;dj-include 'www/components/shadow-include' shadow /&gt;</pre>
 
   <dj-www/components/shadow-include! />
   <dj-www/components/shadow-include shadow />

--- a/example/www/templates/www/include.html
+++ b/example/www/templates/www/include.html
@@ -1,6 +1,16 @@
 <dj-extends 'www/base.html' />
 
 <dj-block 'content'>
+  <style>
+    div {
+      border: 1px solid red;
+      margin: 5px;
+    }
+
+    dj-www-components-include-additional div {
+      border: 1px green solid;
+    }
+  </style>
 
   <pre>&lt;!-- www/components/include.html --&gt;
 
@@ -25,9 +35,21 @@
 
   <pre>&lt;!-- www/include.html --&gt;
 
+&lt;style&gt;
+  div {
+    border: 1px solid red;
+    margin: 5px;
+  }
+
+  dj-www-components-include-additional div {
+    border: 1px green solid;
+  }
+&lt;/style&gt;
+
 &lt;!-- regular includes --&gt;
 &lt;dj-www/components/include /&gt;
 &lt;dj-include 'www/components/include' /&gt;
+&lt;dj-include 'www/components/include:additional' /&gt;
 &lt;dj-include 'www/components/include.html' /&gt;
 
 &lt;!-- shadow includes --&gt;
@@ -35,9 +57,13 @@
 &lt;dj-www/components/shadow-include shadow /&gt;</pre>
 
   <dj-www/components/include />
+  <dj-www/components/include:additional />
   <dj-include 'www/components/include' />
+  <dj-include 'www/components/include:additional' />
   <dj-include 'www/components/include.html' />
 
   <dj-www/components/shadow-include! />
   <dj-www/components/shadow-include shadow />
+  <dj-include 'www/components/shadow-include.html' shadow />
+
 </dj-block 'content'>

--- a/src/dj_angles/replacer.py
+++ b/src/dj_angles/replacer.py
@@ -140,10 +140,15 @@ def get_replacements(template_string: str) -> List[Tuple[str, Any]]:
                 # TODO: Move this to a callable instead of being a one-off
                 is_shadow = False
 
-                if "shadow" in template_tag_args:
-                    # Remove shadow from the arg if necessary
-                    template_tag_args = template_tag_args.replace("shadow", "")
-                    is_shadow = True
+                _template_tag_args = ""
+
+                for template_tag_arg in template_tag_args.split(" "):
+                    if template_tag_arg.strip() == "shadow":
+                        is_shadow = True
+                    else:
+                        _template_tag_args += f"{template_tag_arg} "
+
+                template_tag_args = _template_tag_args
 
                 if not template_tag_args:
                     raise AssertionError("{% include %} must have an template name")

--- a/src/dj_angles/replacer.py
+++ b/src/dj_angles/replacer.py
@@ -15,7 +15,7 @@ def get_wrapping_element_name(template_name: str) -> str:
         .replace("--", "-")
         .replace(" ", "-")
         .replace(":", "-")
-    )
+    ).lower()
     wrapping_element_name = f"dj-{wrapping_element_name}"
 
     # Remove extensions

--- a/src/dj_angles/replacer.py
+++ b/src/dj_angles/replacer.py
@@ -9,7 +9,12 @@ from dj_angles.mappers import HTML_TAG_TO_DJANGO_TEMPLATE_TAG_MAP
 
 def get_wrapping_element_name(template_name: str) -> str:
     wrapping_element_name = (
-        template_name.replace("/", "-").replace("'", "").replace('"', "").replace("--", "-").replace(" ", "-")
+        template_name.replace("/", "-")
+        .replace("'", "")
+        .replace('"', "")
+        .replace("--", "-")
+        .replace(" ", "-")
+        .replace(":", "-")
     )
     wrapping_element_name = f"dj-{wrapping_element_name}"
 
@@ -43,8 +48,14 @@ def get_include_replacement(template_name: str, *, is_shadow: bool = False, is_t
     else:
         template_file = f"'{template_file}'"
 
-    replacement = f"{{% include {template_file} %}}"
     wrapping_element_name = get_wrapping_element_name(template_file)
+
+    if ":" in template_file:
+        colon_idx = template_file.index(":")
+        extension_idx = template_file.index(".")
+        template_file = template_file[0:colon_idx] + template_file[extension_idx:]
+
+    replacement = f"{{% include {template_file} %}}"
 
     if is_shadow:
         replacement = f"<{wrapping_element_name}><template shadowrootmode='open'>{{% include {template_file} %}}"

--- a/tests/dj_angles/replacer/test_get_include_replacement.py
+++ b/tests/dj_angles/replacer/test_get_include_replacement.py
@@ -2,42 +2,49 @@ from dj_angles.replacer import get_include_replacement
 
 
 def test_typical():
-    expected = "{% include 'partial.html' %}"
-    actual = get_include_replacement("partial", is_shadow=False)
+    expected = "<dj-partial>{% include 'partial.html' %}</dj-partial>"
+    actual = get_include_replacement("partial", is_shadow=False, is_tag_self_closing=True)
+
+    assert actual == expected
+
+
+def test_not_self_closing():
+    expected = "<dj-partial>{% include 'partial.html' %}"
+    actual = get_include_replacement("partial", is_shadow=False, is_tag_self_closing=False)
 
     assert actual == expected
 
 
 def test_single_quotes():
-    expected = "{% include 'partial.html' %}"
-    actual = get_include_replacement("'partial.html'", is_shadow=False)
+    expected = "<dj-partial>{% include 'partial.html' %}</dj-partial>"
+    actual = get_include_replacement("'partial.html'", is_shadow=False, is_tag_self_closing=True)
 
     assert actual == expected
 
 
 def test_double_quotes():
-    expected = '{% include "partial.html" %}'
-    actual = get_include_replacement('"partial.html"', is_shadow=False)
+    expected = '<dj-partial>{% include "partial.html" %}</dj-partial>'
+    actual = get_include_replacement('"partial.html"', is_shadow=False, is_tag_self_closing=True)
 
     assert actual == expected
 
 
 def test_extension():
-    expected = "{% include 'partial.html' %}"
-    actual = get_include_replacement("partial.html", is_shadow=False)
+    expected = "<dj-partial>{% include 'partial.html' %}</dj-partial>"
+    actual = get_include_replacement("partial.html", is_shadow=False, is_tag_self_closing=True)
 
     assert actual == expected
 
 
 def test_directory():
-    expected = "{% include 'more/partial.html' %}"
-    actual = get_include_replacement("more/partial", is_shadow=False)
+    expected = "<dj-more-partial>{% include 'more/partial.html' %}</dj-more-partial>"
+    actual = get_include_replacement("more/partial", is_shadow=False, is_tag_self_closing=True)
 
     assert actual == expected
 
 
 def test_shadow():
-    expected = "<template shadowrootmode='open'>{% include 'partial.html' %}</template>"
+    expected = "<dj-partial><template shadowrootmode='open'>{% include 'partial.html' %}</template></dj-partial>"
     actual = get_include_replacement("partial", is_shadow=True, is_tag_self_closing=True)
 
     assert actual == expected

--- a/tests/dj_angles/replacer/test_get_replacements.py
+++ b/tests/dj_angles/replacer/test_get_replacements.py
@@ -15,7 +15,7 @@ ReplacementParams = namedtuple(
 
 
 def _shadowify(s: str) -> str:
-    return f"<template shadowrootmode='open'>{s}</template>"
+    return f"<dj-partial><template shadowrootmode='open'>{s}</template></dj-partial>"
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,7 @@ def _shadowify(s: str) -> str:
         ),
         ReplacementParams(
             template_string="<dj-include 'partial.html' />",
-            replacement_string="{% include 'partial.html' %}",
+            replacement_string="<dj-partial>{% include 'partial.html' %}</dj-partial>",
         ),
         ReplacementParams(
             template_string="<dj-include 'partial.html' shadow />",
@@ -35,7 +35,7 @@ def _shadowify(s: str) -> str:
         ),
         ReplacementParams(
             template_string="<dj-partial />",
-            replacement_string="{% include 'partial.html' %}",
+            replacement_string="<dj-partial>{% include 'partial.html' %}</dj-partial>",
         ),
         ReplacementParams(
             template_string="<dj-comment>",
@@ -113,7 +113,7 @@ def test_typical(template_string, replacement_string):
     (
         ReplacementParams(
             template_string="<dj-include 'partial' />",
-            replacement_string="{% include 'partial.html' %}",
+            replacement_string="<dj-partial>{% include 'partial.html' %}</dj-partial>",
         ),
     ),
 )
@@ -131,7 +131,7 @@ def test_no_extension(template_string, replacement_string):
     (
         ReplacementParams(
             template_string="<$partial />",
-            replacement_string="{% include 'partial.html' %}",
+            replacement_string="<dj-partial>{% include 'partial.html' %}</dj-partial>",
         ),
         ReplacementParams(
             template_string="<$partial! />",
@@ -139,15 +139,15 @@ def test_no_extension(template_string, replacement_string):
         ),
         ReplacementParams(
             template_string="<$partial!>",
-            replacement_string="<template shadowrootmode='open'>{% include 'partial.html' %}",
+            replacement_string="<dj-partial><template shadowrootmode='open'>{% include 'partial.html' %}",
         ),
         ReplacementParams(
             template_string="</$partial!>",
-            replacement_string="</template>",
+            replacement_string="</template></dj-partial>",
         ),
         ReplacementParams(
             template_string="<$directory/partial />",
-            replacement_string="{% include 'directory/partial.html' %}",
+            replacement_string="<dj-directory-partial>{% include 'directory/partial.html' %}</dj-directory-partial>",
         ),
     ),
 )
@@ -167,7 +167,7 @@ def test_initial_tag_regex(template_string, replacement_string, settings):
     (
         ReplacementParams(
             template_string="<Partial />",
-            replacement_string="{% include 'Partial.html' %}",
+            replacement_string="<dj-partial>{% include 'Partial.html' %}</dj-partial>",
         ),
     ),
 )
@@ -187,7 +187,7 @@ def test_initial_tag_regex_for_react_style(template_string, replacement_string, 
     (
         ReplacementParams(
             template_string="<Partial />",
-            replacement_string="{% include 'partial.html' %}",
+            replacement_string="<dj-partial>{% include 'partial.html' %}</dj-partial>",
         ),
     ),
 )
@@ -207,7 +207,7 @@ def test_lower_case_tag(template_string, replacement_string, settings):
     (
         ReplacementParams(
             template_string="<blob 'partial.html' />",
-            replacement_string="{% include 'partial.html' %}",
+            replacement_string="<dj-partial>{% include 'partial.html' %}</dj-partial>",
         ),
     ),
 )

--- a/tests/dj_angles/replacer/test_replace_django_templatetags.py
+++ b/tests/dj_angles/replacer/test_replace_django_templatetags.py
@@ -7,9 +7,9 @@ def test_typical():
 {% block content %}
   <input />
 
-  {% include 'partial.html' %}
+  <dj-partial>{% include 'partial.html' %}</dj-partial>
 
-  {% include 'another-directory/another-partial.html' %}
+  <dj-another-directory-another-partial>{% include 'another-directory/another-partial.html' %}</dj-another-directory-another-partial>
 
   {% debug %}
 {% endblock content %}"""


### PR DESCRIPTION
This would wrap all includes in a custom element. e.g. `<dj-partial shadow />` would get turned into `<dj-partial>{% include 'partial.html' %}</dj-partial>`. The code seems to work as expected according to manually inspecting the output and via tests, however (at least in Vivaldi/Chrome) the dev inspector moves the content of the include to its own node (outside of the `dj-partial` element). It does seem to work in shadow mode, but I am not sure what is happening in non-shadow mode.

Non-shadow mode:
<img width="351" alt="image" src="https://github.com/user-attachments/assets/5c3c4ff0-437f-4745-af39-0d1837206339">

Shadow mode:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ef0d581a-f3f5-417b-996f-877c16822189">

Going to table this for now and return to it when I have time.