### PR TITLE
Default attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.0
+
+- Add support for the following attributes and tags for better HTML lintability:
+    - `template` attribute for `include`
+    - `name` attribute for `block`
+    - `parent` attribute for `extends`
+    - `href` attribute for `css`
+    - `src` attribute for `image`
+
 ## 0.6.1
 
 - Remove `uv.lock` from build.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ https://dj-angles.adamghill.com/
 **`base.html`**
 
 ```html
-<dj-block 'content'>
-</dj-block 'content'>
+<dj-block name='content'>
+</dj-block name='content'>
 ```
 
 **`index.html`**
 
 ```html
-<dj-extends 'base.html' />  <!-- {% extends 'base.html' %} -->
+<dj-extends parent='base.html' />  <!-- {% extends 'base.html' %} -->
 
-<dj-block 'content'>  <!-- {% block 'content' %} -->
-  <dj-include 'partial.html' />  <!-- {% include 'partial.html' %} -->
+<dj-block name='content'>  <!-- {% block content %} -->
+  <dj-include template='partial.html' />  <!-- {% include 'partial.html' %} -->
 
   <dj-verbatim>  <!-- {% verbatim %} -->
     This is verbatim: {% include %}
@@ -60,9 +60,9 @@ https://dj-angles.adamghill.com/
   
   <dj-debug />  <!-- {% debug %} -->
 
-  <dj-image 'img/django.jpg' />  <!-- <img src="{% static 'img/django.jpg' %}" /> -->
-  <dj-css 'css/styles.css' />  <!-- <link href="{% static 'css/styles.css' %}" rel="stylesheet" /> -->
-</dj-block 'content'>  <!-- {% endblock 'content' %} -->
+  <dj-image src='img/django.jpg' />  <!-- <img src="{% static 'img/django.jpg' %}" /> -->
+  <dj-css href='css/styles.css' />  <!-- <link href="{% static 'css/styles.css' %}" rel="stylesheet" /> -->
+</dj-block name='content'>  <!-- {% endblock content %} -->
 ```
 
 **partial.html**

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.7.0
+
+- Add support for the following attributes and tags for better HTML lintability:
+    - `template` attribute for `include`
+    - `name` attribute for `block`
+    - `parent` attribute for `extends`
+    - `href` attribute for `css`
+    - `src` attribute for `image`
+
+## 0.6.1
+
+- Remove `uv.lock` from build.
+
 ## 0.6.0
 
 - Raise more explicit exceptions in some edge cases.

--- a/docs/source/components.md
+++ b/docs/source/components.md
@@ -5,9 +5,11 @@
 These are equivalent ways to include partial HTML files.
 
 ```text
+<dj-partial />
+<dj-include template='partial.html' />
+<dj-include template='partial' />
 <dj-include 'partial.html' />
 <dj-include 'partial' />
-<dj-partial />
 ```
 
 They all compile to the following Django template.
@@ -39,9 +41,12 @@ Would get compiled to the following Django template.
 Accessing templates in directories is supported even though technically forward-slashes [aren't permitted in a custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name). It might confound HTML syntax highlighters.
 
 ```text
+<dj-directory/partial />
+<dj-include template='directory/partial.html' />
+<dj-include template='directory/partial' />
 <dj-include 'directory/partial.html' />
 <dj-include 'directory/partial' />
-<dj-directory/partial />
+
 ```
 
 They all compile to the following Django template.
@@ -57,9 +62,12 @@ To encapsulate component styles, enable the Shadow DOM for the partial. This wil
 These are all equivalent ways to include a shadow partial.
 
 ```text
-<dj-include 'partial.html' shadow />
-<dj-partial shadow />
 <dj-partial! />
+<dj-partial shadow />
+<dj-include template='partial.html' shadow />
+<dj-include template='partial' shadow />
+<dj-include 'partial.html' shadow />
+<dj-include 'partial' shadow />
 ```
 
 They all compile to the following Django template syntax.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,17 +14,17 @@
 **`base.html`**
 
 ```
-<dj-block 'content'>
-</dj-block 'content'>
+<dj-block name='content'>
+</dj-block name='content'>
 ```
 
 **`index.html`**
 
 ```
-<dj-extends 'base.html' />  <!-- {% extends 'base.html' %} -->
+<dj-extends parent='base.html' />  <!-- {% extends 'base.html' %} -->
 
-<dj-block 'content'>  <!-- {% block 'content' %} -->
-  <dj-include 'partial.html' />  <!-- {% include 'partial.html' %} -->
+<dj-block name='content'>  <!-- {% block content %} -->
+  <dj-include template='partial.html' />  <!-- {% include 'partial.html' %} -->
 
   <dj-verbatim>  <!-- {% verbatim %} -->
     This is verbatim: {% include %}
@@ -48,9 +48,9 @@
   
   <dj-debug />  <!-- {% debug %} -->
 
-  <dj-image 'img/django.jpg' />  <!-- <img src="{% static 'img/django.jpg' %}" /> -->
-  <dj-css 'css/styles.css' />  <!-- <link href="{% static 'css/styles.css' %}" rel="stylesheet" /> -->
-</dj-block 'content'>  <!-- {% endblock 'content' %} -->
+  <dj-image src='img/django.jpg' />  <!-- <img src="{% static 'img/django.jpg' %}" /> -->
+  <dj-css href='css/styles.css' />  <!-- <link href="{% static 'css/styles.css' %}" rel="stylesheet" /> -->
+</dj-block name='content'>  <!-- {% endblock content %} -->
 ```
 
 **partial.html**

--- a/docs/source/mappers.md
+++ b/docs/source/mappers.md
@@ -9,7 +9,7 @@
 
 ## Custom mappers
 
-The key of the dictionary is a string and is the text match of the regex after the `initial_tag_regex`, i.e. for the default `initial_tag_regex` of `r"(dj-)"`, the key would be the result after "dj-" until a space or a ">". For example, if "<dj-include 'partial.html' />" was in the HTML, "include" would be looked up in the mapper dictionary to determine what to do with that tag. 
+The key of the dictionary is a string and is the text match of the regex after the `initial_tag_regex`, i.e. for the default `initial_tag_regex` of `r"(dj-)"`, the key would be the result after "dj-" until a space or a ">". For example, if `"<dj-include template='partial.html' />"` was in the HTML, `"include"` would be looked up in the mapper dictionary to determine what to do with that tag. 
 
 The value can either be a string or a callable.
 

--- a/docs/source/tag-elements.md
+++ b/docs/source/tag-elements.md
@@ -39,15 +39,15 @@
 ## [`block`](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#block)
 
 ```
-<dj-block 'content'>
+<dj-block name='content'>
   ...
-</dj-block 'content'>
+</dj-block name='content'>
 ```
 
 ```html
-{% block 'content' %}
+{% block content %}
   ...
-{% endblock 'content' %}
+{% endblock content %}
 ```
 
 ## [`csrf`](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#csrf-token), [`csrf-token`](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#csrf-token), [`csrf-input`](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#csrf-token)
@@ -77,7 +77,7 @@
 ## `css`
 
 ```
-<dj-css 'css/styles.css' />
+<dj-css href='css/styles.css' />
 ```
 
 ```html
@@ -97,7 +97,8 @@
 ## [`extends`](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#extends)
 
 ```
-<dj-extends 'base.html' />
+<dj-extends parent='base' />
+<dj-extends parent='base.html' />
 ```
 
 ```html
@@ -127,7 +128,7 @@
 ## `image`
 
 ```
-<dj-image 'img/django.jpg' />
+<dj-image src='img/django.jpg' />
 ```
 
 ```html

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -26,7 +26,10 @@ SECRET_KEY = "django-insecure-x#vt_3aic#cyvkwell%zb$wfr5yx-^2=mq-_ei2qo!g1$s#_1t
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: List[str] = []
+ALLOWED_HOSTS: List[str] = [
+    "0.0.0.0",
+    "localhost",
+]
 
 
 # Application definition

--- a/example/www/templates/www/base.html
+++ b/example/www/templates/www/base.html
@@ -28,8 +28,8 @@
   </header>
 
   <main>
-    <dj-block 'content'>
-    </dj-block 'content'>
+    <dj-block name='content'>
+    </dj-block name='content'>
   </main>
 
   <footer>

--- a/example/www/templates/www/include.html
+++ b/example/www/templates/www/include.html
@@ -1,6 +1,6 @@
-<dj-extends 'www/base.html' />
+<dj-extends parent='www/base.html' />
 
-<dj-block 'content'>
+<dj-block name='content'>
   <style>
     div {
       border: 1px solid red;
@@ -65,11 +65,13 @@
 
   <pre>&lt;dj-www/components/include /&gt;
 &lt;dj-include 'www/components/include' /&gt;
-&lt;dj-include 'www/components/include.html' /&gt;</pre>
+&lt;dj-include 'www/components/include.html' /&gt;
+&lt;dj-include template='www/components/include.html' /&gt;</pre>
 
   <dj-www/components/include />
   <dj-include 'www/components/include' />
   <dj-include 'www/components/include.html' />
+  <dj-include template='www/components/include.html' />
 
 
   <h4>Regular includes with an additional id</h4>
@@ -81,10 +83,12 @@
   </p>
 
   <pre>&lt;dj-www/components/include:1 /&gt;
-&lt;dj-include 'www/components/include:2' /&gt;</pre>
+&lt;dj-include 'www/components/include:2' /&gt;
+&lt;dj-include template='www/components/include:2' /&gt;</pre>
 
   <dj-www/components/include:1 />
   <dj-include 'www/components/include:2' />
+  <dj-include template='www/components/include:2' />
 
 
   <h3>www/components/shadow-include.html</h3>
@@ -115,10 +119,12 @@
   <pre>
 &lt;dj-www/components/shadow-include! /&gt;
 &lt;dj-www/components/shadow-include shadow /&gt;
+&lt;dj-include template='www/components/shadow-include' shadow /&gt;
 &lt;dj-include 'www/components/shadow-include' shadow /&gt;</pre>
 
   <dj-www/components/shadow-include! />
   <dj-www/components/shadow-include shadow />
+  <dj-include template='www/components/shadow-include.html' shadow />
   <dj-include 'www/components/shadow-include.html' shadow />
 
-</dj-block 'content'>
+</dj-block name='content'>

--- a/example/www/templates/www/index.html
+++ b/example/www/templates/www/index.html
@@ -1,7 +1,7 @@
-<dj-extends 'www/base.html' />
+<dj-extends parent='www/base.html' />
 
-<dj-block 'content'>
+<dj-block name='content'>
   <p>
     This is an example Django site that shows how <code>dj-angles</code> works.
   </p>
-</dj-block 'content'>
+</dj-block name='content'>

--- a/justfile
+++ b/justfile
@@ -1,81 +1,15 @@
-set quiet
-set dotenv-load
-set export
+import? 'adamghill.justfile'
+import? '../dotfiles/just/justfile'
+
+src := "src/dj_angles"
 
 # List commands
 _default:
-    just --list --unsorted --justfile {{justfile()}} --list-heading $'Available commands:\n'
-  
-# Install dependencies
-bootstrap:
-  uv install
+    just --list --unsorted --justfile {{ justfile() }} --list-heading $'Available commands:\n'
 
-# Set up the project
-setup:
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  uv tool install ruff
-  uv tool install build
-  uv tool install twine
-
-# Update the project
-update:
-  uv sync
-
-# Lock the dependencies
-lock:
-  uv sync
-
-# Lint the project
-lint *ARGS='.':
-  -uvx ruff check {{ ARGS }}
-
-# Check the types in the project
-type *ARGS='.':
-  -uv run mypy {{ ARGS }}  # need to run through uv to see installed dependencies
-
-# Benchmark the project
-benchmark:
-  -uv run pytest tests/benchmarks/ --benchmark-only --benchmark-compare
-
-# Run the tests
-test *ARGS='':
-  -uv run pytest {{ ARGS }}
-
-alias t := test
-
-# Run coverage on the code
-coverage:
-  -uv run pytest --cov=src/dj_angles
-
-# Run all the dev things
-dev:
-  just lint
-  just type
-  just coverage
+# Grab default `adamghill.justfile` from GitHub
+fetch:
+  curl https://raw.githubusercontent.com/adamghill/dotfiles/master/just/justfile > adamghill.justfile
 
 serve:
-  uv run python3 example/manage.py migrate
   uv run python3 example/manage.py runserver 0:8789
-
-# Build the package
-build:
-  just test
-  just build-docs
-  rm -rf dist/*
-  uvx --from build pyproject-build --installer uv
-
-# Build and publish the package to test PyPI and prod PyPI
-publish:
-  just build
-  uvx twine check dist/*
-  uvx twine upload -r testpypi dist/*
-  uvx twine upload -r pypi dist/*
-
-# Run documentation site
-serve-docs:
-  uv run sphinx-autobuild -W docs/source docs/build
-
-# Build documentation site
-build-docs:
-  cp CHANGELOG.md docs/source/changelog.md
-  uv run sphinx-build -W docs/source docs/build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ name = "dj-angles"
 authors = [
   {name = "Adam Hill", email = "adam@adamghill.com"}
 ]
-version = "0.6.1"
+version = "0.7.0"
 description = "Add more bracket angles to Django templates </>"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
   "django",
   "html",
@@ -25,8 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "django >= 0",
-  "minestrone >= 0",
-  "dj-app >= 0"
+  "minestrone >= 0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "django"
+  "django >= 0",
+  "minestrone >= 0",
+  "dj-app >= 0"
 ]
 
 [project.urls]
@@ -36,25 +38,25 @@ Changelog = "https://github.com/adamghill/dj-angles/blob/master/CHANGELOG.md"
 
 [project.optional-dependencies]
 docs = [
-  "sphinx",
-  "linkify-it-py",
-  "myst-parser",
-  "sphinx-copybutton",
-  "furo",
-  "sphinx-autobuild",
-  "sphinx-inline-tabs",
-  "sphinx-design",
-  "sphinx-autoapi",
-  "toml",
-  "types-toml"
+  "sphinx >= 0",
+  "linkify-it-py >= 0",
+  "myst-parser >= 0",
+  "sphinx-copybutton >= 0",
+  "furo >= 0",
+  "sphinx-autobuild >= 0",
+  "sphinx-inline-tabs >= 0",
+  "sphinx-design >= 0",
+  "sphinx-autoapi >= 0",
+  "toml >= 0",
+  "types-toml >= 0"
 ]
 
 [tool.uv]
 dev-dependencies = [
-  "pytest<9",
-  "pytest-django",
-  "pytest-cov",
-  "mypy"
+  "pytest < 9",
+  "pytest-django >= 0",
+  "pytest-cov >= 0",
+  "mypy >= 0"
 ]
 
 [tool.ruff]

--- a/src/dj_angles/mappers.py
+++ b/src/dj_angles/mappers.py
@@ -189,4 +189,8 @@ def map_extends(tag: "Tag") -> str:
 
     parent = _get_attribute_value_or_first_key(tag, "parent")
 
+    if "." not in parent:
+        parent = dequotify(parent)
+        parent = f"'{parent}.html'"
+
     return f"{{% {django_template_tag} {parent} %}}"

--- a/src/dj_angles/regex_replacer.py
+++ b/src/dj_angles/regex_replacer.py
@@ -4,13 +4,13 @@ from functools import lru_cache
 from typing import List, Tuple
 
 from dj_angles.exceptions import InvalidEndTagError
-from dj_angles.mappers import map_autoescape, map_css, map_image, map_include
+from dj_angles.mappers import map_autoescape, map_block, map_css, map_extends, map_image, map_include
 from dj_angles.settings import get_setting
 from dj_angles.tags import Tag
 
 HTML_TAG_TO_DJANGO_TEMPLATE_TAG_MAP = {
-    "extends": "extends",
-    "block": "block",
+    "extends": map_extends,
+    "block": map_block,
     "verbatim": "verbatim",
     "include": map_include,
     "comment": "comment",

--- a/src/dj_angles/strings.py
+++ b/src/dj_angles/strings.py
@@ -1,0 +1,5 @@
+def dequotify(s: str) -> str:
+    if (s.startswith("'") and s.endswith("'")) or (s.startswith('"') and s.endswith('"')):
+        return s[1:-1]
+
+    return s

--- a/tests/dj_angles/mappers/test_map_block.py
+++ b/tests/dj_angles/mappers/test_map_block.py
@@ -1,0 +1,37 @@
+import pytest
+
+from dj_angles.exceptions import MissingAttributeError
+from dj_angles.mappers import map_block
+from tests.dj_angles.tags import create_tag
+
+
+def test_string():
+    expected = "{% block content %}"
+
+    html = "<dj-block 'content'>"
+    tag = create_tag(html)
+
+    actual = map_block(tag=tag)
+
+    assert actual == expected
+
+
+def test_name_attribute():
+    expected = "{% block content %}"
+
+    html = "<dj-block name='content'>"
+    tag = create_tag(html)
+
+    actual = map_block(tag=tag)
+
+    assert actual == expected
+
+
+def test_missing_name_throws_exception():
+    html = "<dj-block invalid='content'>"
+    tag = create_tag(html)
+
+    with pytest.raises(MissingAttributeError) as e:
+        map_block(tag=tag)
+
+    assert e.value.name == "name"

--- a/tests/dj_angles/mappers/test_map_css.py
+++ b/tests/dj_angles/mappers/test_map_css.py
@@ -1,0 +1,48 @@
+import pytest
+
+from dj_angles.exceptions import MissingAttributeError
+from dj_angles.mappers import map_css
+from tests.dj_angles.tags import create_tag
+
+
+def test_string():
+    expected = '<link href="{% static \'css/style.css\' %}" rel="stylesheet" />'
+
+    html = "<dj-css 'css/style.css' />"
+    tag = create_tag(html)
+
+    actual = map_css(tag=tag)
+
+    assert actual == expected
+
+
+def test_href_attribute():
+    expected = '<link href="{% static \'css/style.css\' %}" rel="stylesheet" />'
+
+    html = "<dj-css href='css/style.css' />"
+    tag = create_tag(html)
+
+    actual = map_css(tag=tag)
+
+    assert actual == expected
+
+
+def test_href_second_attribute():
+    expected = "<link href=\"{% static 'css/style.css' %}\" invalid='css/style1.css' rel=\"stylesheet\" />"
+
+    html = "<dj-css invalid='css/style1.css' href='css/style.css' />"
+    tag = create_tag(html)
+
+    actual = map_css(tag=tag)
+
+    assert actual == expected
+
+
+def test_missing_href_throws_exception():
+    html = "<dj-css invalid='css/style1.css' />"
+    tag = create_tag(html)
+
+    with pytest.raises(MissingAttributeError) as e:
+        map_css(tag=tag)
+
+    assert e.value.name == "href"

--- a/tests/dj_angles/mappers/test_map_extends.py
+++ b/tests/dj_angles/mappers/test_map_extends.py
@@ -1,0 +1,37 @@
+import pytest
+
+from dj_angles.exceptions import MissingAttributeError
+from dj_angles.mappers import map_extends
+from tests.dj_angles.tags import create_tag
+
+
+def test_string():
+    expected = "{% extends 'base.html' %}"
+
+    html = "<dj-extends 'base.html'>"
+    tag = create_tag(html)
+
+    actual = map_extends(tag=tag)
+
+    assert actual == expected
+
+
+def test_parent_attribute():
+    expected = "{% extends 'base.html' %}"
+
+    html = "<dj-extends parent='base.html'>"
+    tag = create_tag(html)
+
+    actual = map_extends(tag=tag)
+
+    assert actual == expected
+
+
+def test_missing_parent_throws_exception():
+    html = "<dj-extends invalid='base.html'>"
+    tag = create_tag(html)
+
+    with pytest.raises(MissingAttributeError) as e:
+        map_extends(tag=tag)
+
+    assert e.value.name == "parent"

--- a/tests/dj_angles/mappers/test_map_extends.py
+++ b/tests/dj_angles/mappers/test_map_extends.py
@@ -27,6 +27,17 @@ def test_parent_attribute():
     assert actual == expected
 
 
+def test_no_extension():
+    expected = "{% extends 'base.html' %}"
+
+    html = "<dj-extends parent='base'>"
+    tag = create_tag(html)
+
+    actual = map_extends(tag=tag)
+
+    assert actual == expected
+
+
 def test_missing_parent_throws_exception():
     html = "<dj-extends invalid='base.html'>"
     tag = create_tag(html)

--- a/tests/dj_angles/mappers/test_map_image.py
+++ b/tests/dj_angles/mappers/test_map_image.py
@@ -1,0 +1,48 @@
+import pytest
+
+from dj_angles.exceptions import MissingAttributeError
+from dj_angles.mappers import map_image
+from tests.dj_angles.tags import create_tag
+
+
+def test_string():
+    expected = "<img src=\"{% static 'img/blob.png' %}\" />"
+
+    html = "<dj-image 'img/blob.png' />"
+    tag = create_tag(html)
+
+    actual = map_image(tag=tag)
+
+    assert actual == expected
+
+
+def test_src_attribute():
+    expected = "<img src=\"{% static 'img/blob.png' %}\" />"
+
+    html = "<dj-image src='img/blob.png' />"
+    tag = create_tag(html)
+
+    actual = map_image(tag=tag)
+
+    assert actual == expected
+
+
+def test_src_second_attribute():
+    expected = "<img src=\"{% static 'img/blob.png' %}\" width='100' />"
+
+    html = "<dj-image width='100' src='img/blob.png' />"
+    tag = create_tag(html)
+
+    actual = map_image(tag=tag)
+
+    assert actual == expected
+
+
+def test_missing_src_throws_exception():
+    html = "<dj-image invalid='img/blob.png' />"
+    tag = create_tag(html)
+
+    with pytest.raises(MissingAttributeError) as e:
+        map_image(tag=tag)
+
+    assert e.value.name == "src"

--- a/tests/dj_angles/mappers/test_map_include.py
+++ b/tests/dj_angles/mappers/test_map_include.py
@@ -77,3 +77,14 @@ def test_shadow():
     actual = map_include(tag=tag)
 
     assert actual == expected
+
+
+def test_template_attribute():
+    expected = "<dj-partial>{% include 'partial.html' %}</dj-partial>"
+
+    html = "<dj-include template='partial.html' />"
+    tag = create_tag(html)
+
+    actual = map_include(tag=tag)
+
+    assert actual == expected

--- a/tests/dj_angles/regex_replacer/test_get_replacements.py
+++ b/tests/dj_angles/regex_replacer/test_get_replacements.py
@@ -7,10 +7,7 @@ from dj_angles.regex_replacer import get_replacements
 # Structure to store parameterize data
 ReplacementParams = namedtuple(
     "ReplacementParams",
-    (
-        "template_string",
-        "replacement_string",
-    ),
+    ("template_string", "replacement_string"),
 )
 
 
@@ -23,6 +20,10 @@ def _shadowify(s: str) -> str:
     (
         ReplacementParams(
             template_string="<dj-extends 'base.html' />",
+            replacement_string="{% extends 'base.html' %}",
+        ),
+        ReplacementParams(
+            template_string="<dj-extends parent='base.html' />",
             replacement_string="{% extends 'base.html' %}",
         ),
         ReplacementParams(
@@ -98,16 +99,24 @@ def _shadowify(s: str) -> str:
             replacement_string="{% csrf_token %}",
         ),
         ReplacementParams(
-            template_string="<dj-block>",
-            replacement_string="{% block %}",
+            template_string="<dj-block name='content'>",
+            replacement_string="{% block content %}",
+        ),
+        ReplacementParams(
+            template_string="</dj-block name='content'>",
+            replacement_string="{% endblock content %}",
+        ),
+        ReplacementParams(
+            template_string="<dj-block 'content'>",
+            replacement_string="{% block content %}",
+        ),
+        ReplacementParams(
+            template_string="</dj-block 'content'>",
+            replacement_string="{% endblock content %}",
         ),
         ReplacementParams(
             template_string="<dj-block content>",
             replacement_string="{% block content %}",
-        ),
-        ReplacementParams(
-            template_string="</dj-block>",
-            replacement_string="{% endblock %}",
         ),
         ReplacementParams(
             template_string="</dj-block content>",


### PR DESCRIPTION
HTML element attributes are not supposed to start with single/double quotes, so adding support for default attributes for some tags to play nicer with HTML syntax highlighters, e.g. https://github.com/kristoff-it/superhtml. Value-less attributes will still be technically supported for these tags for now, but the docs will be updated to show this preferred approach going forward.

- `<dj-extends parent="..." />`
- `<dj-block name="..." />`
- `<dj-image src="..." />`
- `<dj-css href="..." />`