### PR TITLE
Allow for a customizable fallback mapper

### DIFF
--- a/docs/source/integrations/django-bird.md
+++ b/docs/source/integrations/django-bird.md
@@ -13,6 +13,9 @@ Using the auto settings in `django-bird` will unfortunately create a conflict wi
 ```python
 # settings.py
 
+from dj_angles.mappers.thirdparty import map_bird
+
+
 DJANGO_BIRD = {
     "ENABLE_AUTO_CONFIG": False
 }  # this is required for `django-bird`
@@ -47,6 +50,10 @@ TEMPLATES = [
         },
     },
 ]
+
+ANGLE = {
+    "mapper": map_bird
+}
 ```
 
 ## Example
@@ -57,6 +64,31 @@ TEMPLATES = [
 <dj-bird template='button' class='btn'>
   Click me!
 </dj-bird>
+```
+
+**templates/bird/button.html**
+
+```
+<button {{ attrs }}>
+  {{ slot }}
+</button>
+```
+
+### Using `default_component_mapper`
+
+```python
+# settings.py
+ANGLES = {
+    "default_component_mapper": "dj_angles.mappers.thirdparty.map_bird_component",
+}
+```
+
+**templates/index.html**
+
+```html
+<dj-button class='btn'>
+  Click me!
+</dj-button>
 ```
 
 **templates/bird/button.html**

--- a/docs/source/settings.md
+++ b/docs/source/settings.md
@@ -62,3 +62,7 @@ Lower-cases the tag. Useful when using [React-style includes](#react-style-inclu
 ## `mappers`
 
 Provide additional mappers. `Dictionary` which defaults to `{}`. More details about [mappers](mappers.md).
+
+## `default_component_mapper`
+
+Provide a default mapper. This defaults to `dj_angles.mappers.include.map_include`

--- a/docs/source/settings.md
+++ b/docs/source/settings.md
@@ -65,4 +65,4 @@ Provide additional mappers. `Dictionary` which defaults to `{}`. More details ab
 
 ## `default_component_mapper`
 
-Provide a default mapper. This defaults to `dj_angles.mappers.include.map_include`
+Provide a default mapper. This defaults to `dj_angles.mappers.angle.map_include_when_no_tag`

--- a/src/dj_angles/mappers/angles.py
+++ b/src/dj_angles/mappers/angles.py
@@ -4,11 +4,21 @@ from django.template import engines
 from django.template.exceptions import TemplateDoesNotExist
 from minestrone import HTML
 
-from dj_angles.mappers.include import get_include_template_file
+from dj_angles.mappers.include import get_include_template_file, map_include
 from dj_angles.strings import dequotify
 
 if TYPE_CHECKING:
     from dj_angles.tags import Tag
+
+
+def map_include_when_no_tag(tag: "Tag") -> str:
+    tag.attributes.prepend(tag.component_name)
+    django_template_tag = map_include(tag)
+
+    if tag.is_end and tag.is_shadow or (tag.start_tag and tag.start_tag.is_shadow):
+        django_template_tag = f"</template>{django_template_tag}"
+
+    return django_template_tag
 
 
 def map_angles_include(tag: "Tag") -> str:

--- a/src/dj_angles/mappers/thirdparty.py
+++ b/src/dj_angles/mappers/thirdparty.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import logging
 from typing import TYPE_CHECKING
 
@@ -11,10 +12,18 @@ logger = logging.getLogger(__name__)
 
 
 def map_bird(tag: "Tag") -> str:
+    return _stub_map_bird(tag, lambda tag: get_attribute_value_or_first_key(tag, "template"))
+
+
+def map_bird_component(tag: "Tag") -> str:
+    return _stub_map_bird(tag, lambda tag: tag.component_name)
+
+
+def _stub_map_bird(tag: "Tag", get_template_for_tag: Callable[["Tag"], str]) -> str:
     if tag.is_end:
         return "{% endbird %}"
 
-    template = get_attribute_value_or_first_key(tag, "template")
+    template = get_template_for_tag(tag)
     django_template_tag = f"{{% bird {template}"
 
     if tag.attributes:

--- a/src/dj_angles/tags.py
+++ b/src/dj_angles/tags.py
@@ -82,24 +82,11 @@ class Tag:
             param slots: List of slots which is a tuple of slot name and inner html.
         """
 
-        if self.django_template_tag is None and self.is_end:
-            wrapping_tag_name = self.get_wrapping_tag_name()
-
-            django_template_tag = ""
-
-            if self.is_shadow or (self.start_tag and self.start_tag.is_shadow):
-                django_template_tag = "</template>"
-
-            return f"{django_template_tag}</{wrapping_tag_name}>"
-
         if self.django_template_tag is None:
             # Assume any missing template tag should use the fallback mapper
             self.django_template_tag = import_string(
-                get_setting("default_component_mapper", "dj_angles.mappers.include.map_include")
+                get_setting("default_component_mapper", "dj_angles.mappers.angles.map_include_when_no_tag")
             )
-
-            # Add component name to the template tags
-            self.attributes.prepend(self.component_name)
 
         if slots and self.is_include:
             self.django_template_tag = map_angles_include

--- a/src/dj_angles/tags.py
+++ b/src/dj_angles/tags.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Optional
 
 from minestrone import Element
 
+from django.utils.module_loading import import_string
+
 from dj_angles.attributes import Attributes
 from dj_angles.mappers.angles import map_angles_include
 from dj_angles.mappers.include import map_include
@@ -92,8 +94,10 @@ class Tag:
             return f"{django_template_tag}</{wrapping_tag_name}>"
 
         if self.django_template_tag is None:
-            # Assume any missing template tag is an include
-            self.django_template_tag = map_include
+            # Assume any missing template tag should use the fallback mapper
+            self.django_template_tag = import_string(
+                get_setting("fallback_mapper", "dj_angles.mappers.include.map_include")
+            )
 
             # Add component name to the template tags
             self.attributes.prepend(self.component_name)

--- a/src/dj_angles/tags.py
+++ b/src/dj_angles/tags.py
@@ -6,7 +6,6 @@ from django.utils.module_loading import import_string
 
 from dj_angles.attributes import Attributes
 from dj_angles.mappers.angles import map_angles_include
-from dj_angles.mappers.include import map_include
 from dj_angles.settings import get_setting
 
 if TYPE_CHECKING:
@@ -96,7 +95,7 @@ class Tag:
         if self.django_template_tag is None:
             # Assume any missing template tag should use the fallback mapper
             self.django_template_tag = import_string(
-                get_setting("fallback_mapper", "dj_angles.mappers.include.map_include")
+                get_setting("default_component_mapper", "dj_angles.mappers.include.map_include")
             )
 
             # Add component name to the template tags

--- a/tests/dj_angles/mappers/thirdparty/test_map_bird_component.py
+++ b/tests/dj_angles/mappers/thirdparty/test_map_bird_component.py
@@ -2,20 +2,17 @@ from dj_angles.mappers.thirdparty import map_bird_component
 from tests.dj_angles.tags import create_tag
 
 
-def override_setting(settings, key, value):
-    old_value = getattr(settings, key, None)
-    setattr(settings, key, value)
+def override_setting(settings, value):
+    old_value = settings.ANGLES.get("default_component_mapper", "dj_angles.mappers.include.map_include")
+    settings.ANGLES["default_component_mapper"] = "dj_angles.mappers.thirdparty.map_bird_component"
     return old_value
 
 
-def restore_setting(settings, key, old_value):
-    setattr(settings, key, old_value)
+def restore_setting(settings, old_value):
+    settings.ANGLES["default_component_mapper"] = old_value
 
 
 def test_not_self_closing(settings):
-    initial_setting = override_setting(settings, "default_component_mapper", "dj_angles.mappers.thirdparty.map_bird_component")
-    assert True == True
-    restore_setting(settings, "default_component_mapper", initial_setting)
     expected = "{% bird partial %}"
 
     html = "<dj-partial>"
@@ -27,8 +24,6 @@ def test_not_self_closing(settings):
 
 
 def test_is_closing(settings):
-    initial_setting = override_setting(settings, "default_component_mapper", "dj_angles.mappers.thirdparty.map_bird_component")
-
     expected = "{% endbird %}"
 
     html = "</dj-partial>"
@@ -37,11 +32,9 @@ def test_is_closing(settings):
     actual = map_bird_component(tag=tag)
 
     assert actual == expected
-    restore_setting(settings, "default_component_mapper", initial_setting)
 
 
 def test_self_closing(settings):
-    initial_setting = override_setting(settings, "default_component_mapper", "dj_angles.mappers.thirdparty.map_bird_component")
 
     expected = "{% bird partial / %}"
 
@@ -51,4 +44,39 @@ def test_self_closing(settings):
     actual = map_bird_component(tag=tag)
 
     assert actual == expected
-    restore_setting(settings, "default_component_mapper", initial_setting)
+
+
+def test_not_self_closing_from_settings(settings):
+    settings.ANGLES["default_component_mapper"] = "dj_angles.mappers.thirdparty.map_bird_component"
+    expected = "{% bird partial %}"
+
+    html = "<dj-partial>"
+    tag = create_tag(html)
+
+    actual = tag.get_django_template_tag()
+
+    assert actual == expected
+
+
+def test_self_closing_from_settings(settings):
+    settings.ANGLES["default_component_mapper"] = "dj_angles.mappers.thirdparty.map_bird_component"
+    expected = "{% bird partial / %}"
+
+    html = "<dj-partial />"
+
+    tag = create_tag(html)
+    actual = tag.get_django_template_tag()
+
+    assert expected == actual
+
+
+def test_closing_from_settings(settings):
+    settings.ANGLES["default_component_mapper"] = "dj_angles.mappers.thirdparty.map_bird_component"
+    expected = "{% endbird %}"
+
+    html = "</dj-partial>"
+
+    tag = create_tag(html)
+    actual = tag.get_django_template_tag()
+
+    assert expected == actual

--- a/tests/dj_angles/mappers/thirdparty/test_map_bird_component.py
+++ b/tests/dj_angles/mappers/thirdparty/test_map_bird_component.py
@@ -1,0 +1,54 @@
+from dj_angles.mappers.thirdparty import map_bird_component
+from tests.dj_angles.tags import create_tag
+
+
+def override_setting(settings, key, value):
+    old_value = getattr(settings, key, None)
+    setattr(settings, key, value)
+    return old_value
+
+
+def restore_setting(settings, key, old_value):
+    setattr(settings, key, old_value)
+
+
+def test_not_self_closing(settings):
+    initial_setting = override_setting(settings, "default_component_mapper", "dj_angles.mappers.thirdparty.map_bird_component")
+    assert True == True
+    restore_setting(settings, "default_component_mapper", initial_setting)
+    expected = "{% bird partial %}"
+
+    html = "<dj-partial>"
+    tag = create_tag(html)
+
+    actual = map_bird_component(tag=tag)
+
+    assert actual == expected
+
+
+def test_is_closing(settings):
+    initial_setting = override_setting(settings, "default_component_mapper", "dj_angles.mappers.thirdparty.map_bird_component")
+
+    expected = "{% endbird %}"
+
+    html = "</dj-partial>"
+    tag = create_tag(html)
+
+    actual = map_bird_component(tag=tag)
+
+    assert actual == expected
+    restore_setting(settings, "default_component_mapper", initial_setting)
+
+
+def test_self_closing(settings):
+    initial_setting = override_setting(settings, "default_component_mapper", "dj_angles.mappers.thirdparty.map_bird_component")
+
+    expected = "{% bird partial / %}"
+
+    html = "<dj-partial />"
+    tag = create_tag(html)
+
+    actual = map_bird_component(tag=tag)
+
+    assert actual == expected
+    restore_setting(settings, "default_component_mapper", initial_setting)

--- a/tests/dj_angles/tags/test_tag.py
+++ b/tests/dj_angles/tags/test_tag.py
@@ -19,6 +19,7 @@ def test_get_wrapping_tag_name_with_name():
     assert expected == actual
 
 
+
 def test_get_wrapping_tag_name_component():
     expected = "dj-partial"
 
@@ -33,5 +34,16 @@ def test_get_wrapping_tag_name_component_with_key():
 
     tag = create_tag("<dj-partial:1 />")
     actual = tag.get_wrapping_tag_name()
+
+    assert expected == actual
+
+
+def test_default_mapping(settings):
+    expected = "<dj-partial>{% include 'partial.html' %}</dj-partial>"
+
+    html = "<dj-partial />"
+
+    tag = create_tag(html)
+    actual = tag.get_django_template_tag()
 
     assert expected == actual


### PR DESCRIPTION
Hello,

I'm not sure whether you're accepting pull requests or not. If you're not, feel free to close!

My thinking here is to be able to set a `fallback_mapper` in the settings that defaults to `dj_angles.mappers.django.map_include`.

What one would be able to able to accomplish by switching the fallback mapper is to use their favorite component library as fallback instead of `{% include %}`.

So for example, assuming django bird, with the appropriate mapper:
`<dj-partial />` would be mapped to `{% bird partial %}{% endbird %}`  instead of `{% include 'partial.html' %}`

I'm opening this as draft, as if that's something you'd be interested in, documentation would be needed