### PR TITLE
Fix django-bird integration when using the default mapper

### DIFF
--- a/src/dj_angles/mappers/thirdparty.py
+++ b/src/dj_angles/mappers/thirdparty.py
@@ -16,10 +16,11 @@ def map_bird(tag: "Tag") -> str:
 
     template_file = tag.tag_name
 
-    try:
-        template_file = tag.get_attribute_value_or_first_key("template")
-    except MissingAttributeError:
-        pass
+    if template_file == "bird":
+        try:
+            template_file = tag.get_attribute_value_or_first_key("template")
+        except MissingAttributeError:
+            pass
 
     django_template_tag = f"{{% bird {template_file}"
 

--- a/tests/dj_angles/mappers/thirdparty/test_map_bird.py
+++ b/tests/dj_angles/mappers/thirdparty/test_map_bird.py
@@ -127,3 +127,16 @@ def test_get_django_template_tag_is_end(settings):
     actual = tag.get_django_template_tag()
 
     assert expected == actual
+
+
+def test_get_django_template_tag_with_attributes(settings):
+    settings.ANGLES["default_mapper"] = "dj_angles.mappers.map_bird"
+
+    expected = "{% bird partial blob='test' %}"
+
+    html = "<dj-partial blob='test'>"
+
+    tag = create_tag(html)
+    actual = tag.get_django_template_tag()
+
+    assert expected == actual


### PR DESCRIPTION
This PR addresses an issue I discovered when using the `django-bird` integration, and specifically the default mapper that allows us to use a short `<dj-button>` tag instead of the longer `<dj-bird button>` tag.

Currently, when using the short form, the first attribute passed to the tag is eaten by the `map_bird` mapper as it looks for the `template` parameter, which is unnecessary as the template name can be derived from the tag name instead.

For example, with the following component:

```django
# bird/button.html
<button {{ attrs }}>
  {{ slot }}
</button>
```

Rendered using the following template:

```html
<dj-bird button class='btn btn-primary' title='button title'>
  Click me!
</dj-bird>
<dj-button class='btn btn-primary' title='button title'>
  Click me!
</dj-button>
```

Results in the following HTML

```html
<button class="btn btn-primary" title="button title">
  Click me!
</button>
<button title="button title">
  Click me!
</button>
```

Note how the first attribute passed to the `<dj-button>` tag is dropped, which doesn't occur when using `<dj-bird button>` (or `<dj-bird template="button">`).
