### PR TITLE
skip template conversion when no dj-angles syntax present

### DIFF
--- a/src/dj_angles/template_loader.py
+++ b/src/dj_angles/template_loader.py
@@ -1,10 +1,12 @@
 import os
+import re
 
 from django.apps import apps
 from django.template import TemplateDoesNotExist
 from django.template.loaders.app_directories import Loader as AppDirectoriesLoader
 
 from dj_angles.regex_replacer import convert_template
+from dj_angles.settings import get_setting, get_tag_regex
 
 
 class Loader(AppDirectoriesLoader):
@@ -21,6 +23,17 @@ class Loader(AppDirectoriesLoader):
         """Gets the converted template contents."""
 
         template_string = self._get_template_string(origin.name)
+
+        initial_attribute_regex = get_setting("initial_attribute_regex", default=r"(dj-)")
+        attribute_pattern = (
+            rf"\s(?:(?:{initial_attribute_regex})(?:if|elif)=|(?:{initial_attribute_regex})(?:else| endif|fi))"
+        )
+
+        tag_regex = get_tag_regex()
+
+        if not re.search(attribute_pattern, template_string) and not tag_regex.search(template_string):
+            return template_string
+
         converted_template_string = convert_template(template_string)
 
         return converted_template_string


### PR DESCRIPTION
👋 This is a follow up PR to Discussion #12.

Unfortunately, I wasn't able to create a minimal, reliable reproduction case for the specific hanging behavior I encountered, or find the time to dig through **all** the logs to see if I could narrow it down further. So, the exact root cause is still a bit murky. My best guess is that `convert_template` might be getting stuck or doing a lot of unnecessary regex work on *every* template loaded, even those without any dj-angles features, potentially triggering an issue on more complex templates.

Instead of passing all templates through the conversion process, this change adds a quick pre-check inside `Loader.get_contents`. It looks for specific dj-angles attributes (`dj-if`, etc.) or tags matching the configured regex. If it doesn't find any of that syntax, it returns early with the original template content unaltered and unprocessed.

With this change, all of my project's templates are able to be rendered correctly – those with dj-angles tags and those without, as well as if the default tag prefix (`dj-`) setting has been changed.

I tried to keep this change pretty minimal and stick it right inside `get_contents`, as well as match the existing style seen throughout the codebase. But I'm definitely open to feedback! If this logic makes more sense somewhere else, needs refactoring, or if you have other ideas, just let me know.

EDIT: I spoke too soon. I installed this branch into my project and I am still seeing the issue. 🙃 Interestingly if I instead use the `filesystem.Loader` as the base inherited class instead of the `app_directories.Loader`, this problem goes away.